### PR TITLE
Add make commands for listing and tagging instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,3 +161,9 @@ tag-instances:
 	aws ec2 create-tags \
 		--resources $(instances) \
 		--tags Key=resource-booking/application,Value=$(tag)
+
+.PHONY: mark-managed
+mark-managed:
+	aws ec2 create-tags \
+		--resources $(instances) \
+		--tags Key=resource-booking/managed,Value=$(enable)


### PR DESCRIPTION
With this one we introduce shortcuts to aws cli:
- Listing instances with: 
```
$ make list-instances

-------------------------------------------------
|               DescribeInstances               |
+----------------------+----------+-------------+
|       Instance       | Managed  |  Resource   |
+----------------------+----------+-------------+
|  i-0b1b591a931567907 |  true    |  analytics  |
|  i-0073357fb586b5a74 |  None    |  None       |
|  i-09bf70d1832a14871 |  true    |  web        |
|  i-0e7f363c3871a249f |  true    |  analytics  |
|  i-0bf4736484ecdfef5 |  true    |  web        |
+----------------------+----------+-------------+
```
- Tagging instances with:
```
make tag-instances instances="i-09bf70d1832a14871 i-0bf4736484ecdfef5" tag=web
```