### PR TITLE
Fix some issues

### DIFF
--- a/controllers/resource_controller.go
+++ b/controllers/resource_controller.go
@@ -77,30 +77,28 @@ func (r *ResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		status = clients.StatusPending
 	}
 
-	if resource.Spec.BookedBy != "" {
-		if status != clients.StatusRunning {
-			startInput := clients.ResourceStartInput{UID: resource.Spec.BookedBy, EndAt: resource.Spec.BookedUntil}
-			if err := cloudResource.Start(startInput); err != nil {
-				log.Error(err, "Error starting resource instances")
-				return ctrl.Result{RequeueAfter: time.Duration(time.Second * 60)}, nil
-			}
-		}
-	} else {
-		if status == clients.StatusRunning {
-			stopInput := clients.ResourceStopInput{UID: resource.Status.LockedBy}
-			if err := cloudResource.Stop(stopInput); err != nil {
-				log.Error(err, "Error stopping resource instances")
-				return ctrl.Result{RequeueAfter: time.Duration(time.Second * 60)}, nil
-			}
-		}
-	}
-
 	resource.Status = managerv1.ResourceStatus{
 		LockedBy:    rStat.LockedBy,
 		LockedUntil: rStat.LockedUntil,
 		Instances:   rStat.Available,
 		Running:     rStat.Running,
 		Status:      status,
+	}
+
+	if resource.Spec.BookedBy != "" {
+		if status != clients.StatusRunning {
+			startInput := clients.ResourceStartInput{UID: resource.Spec.BookedBy, EndAt: resource.Spec.BookedUntil}
+			if err := cloudResource.Start(startInput); err != nil {
+				log.Error(err, "Error starting resource instances")
+			}
+		}
+	} else {
+		if status == clients.StatusRunning {
+			stopInput := clients.ResourceStopInput{UID: resource.Spec.BookedBy}
+			if err := cloudResource.Stop(stopInput); err != nil {
+				log.Error(err, "Error stopping resource instances")
+			}
+		}
 	}
 
 	err = r.Status().Update(ctx, &resource)


### PR DESCRIPTION
- Send the spec field to Stop() to avoid falsely allowing to manage resources booked by other users.
- Move the resource status set before calling Start() or Stop() so its fields can be properly used in these functions.
- Don't return and still Update() a resource if there is an error from Start() or Stop()